### PR TITLE
BE: [feat] 설문 자가진단 구현 #38

### DIFF
--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/controller/DiagnosisController.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/controller/DiagnosisController.java
@@ -1,6 +1,8 @@
 package gradude.springVision.domain.diagnosis.controller;
 
+import gradude.springVision.domain.diagnosis.dto.request.SelfDiagnosisRequestDTO;
 import gradude.springVision.domain.diagnosis.dto.response.AiDiagnosisResposneDTO;
+import gradude.springVision.domain.diagnosis.dto.response.DiagnosisResponseDTO;
 import gradude.springVision.domain.diagnosis.service.DiagnosisCommandService;
 import gradude.springVision.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +25,7 @@ public class DiagnosisController {
 
     @Operation(summary = "안면 자가 진단")
     @PostMapping(value = "/face", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ApiResponse<AiDiagnosisResposneDTO> faceDiagnosis(@AuthenticationPrincipal Long userId, MultipartFile file) {
+    public ApiResponse<Object> faceDiagnosis(@AuthenticationPrincipal Long userId, MultipartFile file) {
         return ApiResponse.onSuccess(diagnosisCommandService.faceDiagnosis(userId, file));
     }
 
@@ -31,5 +33,11 @@ public class DiagnosisController {
     @PostMapping(value = "/speech", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<AiDiagnosisResposneDTO> speechDiagnosis(@AuthenticationPrincipal Long userId, MultipartFile file) {
         return ApiResponse.onSuccess(diagnosisCommandService.speechDiagnosis(userId, file));
+    }
+
+    @Operation(summary = "설문 자가 진단")
+    @PostMapping(value = "/survey", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<DiagnosisResponseDTO> selfDiagnosis(@AuthenticationPrincipal Long userId, SelfDiagnosisRequestDTO selfDiagnosisRequestDTO) {
+        return ApiResponse.onSuccess(diagnosisCommandService.selfDiagnosis(userId, selfDiagnosisRequestDTO));
     }
 }

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/dto/request/SelfDiagnosisRequestDTO.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/dto/request/SelfDiagnosisRequestDTO.java
@@ -1,0 +1,22 @@
+package gradude.springVision.domain.diagnosis.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class SelfDiagnosisRequestDTO {
+
+    private int alertness;
+    private int orientation;
+    private int gaze;
+    private int visualField;
+    private int leftArm;
+    private int rightArm;
+    private int leftLeg;
+    private int rightLeg;
+    private int limbAtaxia;
+    private int sensory;
+    private int aphasia;
+    private int neglect;
+}

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/dto/response/DiagnosisResponseDTO.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/dto/response/DiagnosisResponseDTO.java
@@ -1,0 +1,46 @@
+package gradude.springVision.domain.diagnosis.dto.response;
+
+import gradude.springVision.domain.diagnosis.entity.Diagnosis;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class DiagnosisResponseDTO {
+
+    private boolean face;
+    private boolean speech;
+    private int alertness;
+    private int orientation;
+    private int gaze;
+    private int visualField;
+    private int leftArm;
+    private int rightArm;
+    private int leftLeg;
+    private int rightLeg;
+    private int limbAtaxia;
+    private int sensory;
+    private int aphasia;
+    private int neglect;
+    private int totalScore;
+
+    public static DiagnosisResponseDTO from(Diagnosis diagnosis) {
+        return DiagnosisResponseDTO.builder()
+                .face(diagnosis.isFace())
+                .speech(diagnosis.isSpeech())
+                .alertness(diagnosis.getAlertness())
+                .orientation(diagnosis.getOrientation())
+                .gaze(diagnosis.getGaze())
+                .visualField(diagnosis.getVisualField())
+                .leftArm(diagnosis.getLeftArm())
+                .rightArm(diagnosis.getRightArm())
+                .leftLeg(diagnosis.getLeftLeg())
+                .rightLeg(diagnosis.getRightLeg())
+                .limbAtaxia(diagnosis.getLimbAtaxia())
+                .sensory(diagnosis.getSensory())
+                .aphasia(diagnosis.getAphasia())
+                .neglect(diagnosis.getNeglect())
+                .totalScore(diagnosis.getTotalScore())
+                .build();
+    }
+}

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/entity/Diagnosis.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/entity/Diagnosis.java
@@ -3,6 +3,8 @@ package gradude.springVision.domain.diagnosis.entity;
 import gradude.springVision.domain.user.entity.User;
 import gradude.springVision.global.util.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 
 @Entity
@@ -29,19 +31,41 @@ public class Diagnosis extends BaseEntity {
     @Column(nullable = false)
     private double speechProbability;
 
-    private boolean paralysis;
+    @Min(0) @Max(3)
+    private int alertness; // 의식 수준
 
-    private boolean language;
+    @Min(0) @Max(2)
+    private int orientation; // 의식 질문
 
-    private boolean movement;
+    @Min(0) @Max(2)
+    private int gaze; // 시선
 
-    private boolean vision;
+    @Min(0) @Max(3)
+    private int visualField; // 시야
 
-    private boolean swallowing;
+    @Min(0) @Max(4)
+    private int leftArm; // 왼쪽 팔 운동
 
-    private boolean cognition;
+    @Min(0) @Max(4)
+    private int rightArm; // 오른쪽 팔 운동
 
-    private boolean headache;
+    @Min(0) @Max(4)
+    private int leftLeg;  // 왼쪽 다리 운동
+
+    @Min(0) @Max(4)
+    private int rightLeg; // 오른쪽 다리 운동
+
+    @Min(0) @Max(2)
+    private int limbAtaxia; // 운동 실조
+
+    @Min(0) @Max(2)
+    private int sensory; // 감각
+
+    @Min(0) @Max(3)
+    private int aphasia; // 언어
+
+    @Min(0) @Max(2)
+    private int neglect; // 편측 무시
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/entity/Diagnosis.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/entity/Diagnosis.java
@@ -1,5 +1,6 @@
 package gradude.springVision.domain.diagnosis.entity;
 
+import gradude.springVision.domain.diagnosis.dto.request.SelfDiagnosisRequestDTO;
 import gradude.springVision.domain.user.entity.User;
 import gradude.springVision.global.util.BaseEntity;
 import jakarta.persistence.*;
@@ -67,7 +68,30 @@ public class Diagnosis extends BaseEntity {
     @Min(0) @Max(2)
     private int neglect; // 편측 무시
 
+    private int totalScore;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    public void updateDiagnosis(boolean speech, double speechProbability) {
+        this.speech = speech;
+        this.speechProbability = speechProbability;
+    }
+
+    public void updateDiagnosis(SelfDiagnosisRequestDTO dto, int totalScore) {
+        this.alertness = dto.getAlertness();
+        this.orientation = dto.getOrientation();
+        this.gaze = dto.getGaze();
+        this.visualField = dto.getVisualField();
+        this.leftArm = dto.getLeftArm();
+        this.rightArm = dto.getRightArm();
+        this.leftLeg = dto.getLeftLeg();
+        this.rightLeg = dto.getRightLeg();
+        this.limbAtaxia = dto.getLimbAtaxia();
+        this.sensory = dto.getSensory();
+        this.aphasia = dto.getAphasia();
+        this.neglect = dto.getNeglect();
+        this.totalScore = totalScore;
+    }
 }

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/repository/DiagnosisRepository.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/repository/DiagnosisRepository.java
@@ -3,6 +3,9 @@ package gradude.springVision.domain.diagnosis.repository;
 import gradude.springVision.domain.diagnosis.entity.Diagnosis;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DiagnosisRepository extends JpaRepository<Diagnosis, Long> {
 
+    Optional<Diagnosis> findTopByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/Backend/src/main/java/gradude/springVision/global/common/response/ErrorCode.java
+++ b/Backend/src/main/java/gradude/springVision/global/common/response/ErrorCode.java
@@ -38,7 +38,10 @@ public enum ErrorCode {
 
     // AI Error
     AI_PREDICTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI500", "AI 모델 진단 실패입니다."),
-    AI_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI500", "AI 모델 호출 실패입니다.");
+    AI_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI501", "AI 모델 호출 실패입니다."),
+
+    // Diagnosis Error
+    DIAGNOSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "HOSPITAL4000", "병원을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #38

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- Diagnosis 엔티티에 설문조사 속성 추가
- 설문 자가진단 구현
- 자가진단 플로우 최종 결과 저장 및 반환

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
수정해야함!!!! totalScore계산하는거..