### PR TITLE
FE: [feat] 카카오 로그인 및 회원가입 API 연동

### DIFF
--- a/Frontend/App.tsx
+++ b/Frontend/App.tsx
@@ -5,18 +5,8 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import queryClient from './src/api/queryClient';
 import RootNavigator from './src/navigations/root/RootNavigator';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
-import {hideSplash, showSplash} from 'react-native-splash-view';
 
 function App() {
-  // 로그인 api 연동 시, 이거 지우고 root navi에 설정하기
-  showSplash();
-
-  useEffect(() => {
-    setTimeout(() => {
-      hideSplash();
-    }, 500);
-  }, []);
-
   return (
     <SafeAreaProvider>
       <QueryClientProvider client={queryClient}>

--- a/Frontend/App.tsx
+++ b/Frontend/App.tsx
@@ -5,18 +5,22 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import queryClient from './src/api/queryClient';
 import RootNavigator from './src/navigations/root/RootNavigator';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
+import {Provider as ReduxProvider} from 'react-redux';
+import {store} from './src/store';
 
 function App() {
   return (
-    <SafeAreaProvider>
-      <QueryClientProvider client={queryClient}>
-        <SafeAreaProvider>
-          <NavigationContainer>
-            <RootNavigator />
-          </NavigationContainer>
-        </SafeAreaProvider>
-      </QueryClientProvider>
-    </SafeAreaProvider>
+    <ReduxProvider store={store}>
+      <SafeAreaProvider>
+        <QueryClientProvider client={queryClient}>
+          <SafeAreaProvider>
+            <NavigationContainer>
+              <RootNavigator />
+            </NavigationContainer>
+          </SafeAreaProvider>
+        </QueryClientProvider>
+      </SafeAreaProvider>
+    </ReduxProvider>
   );
 }
 

--- a/Frontend/ios/Config.xcconfig
+++ b/Frontend/ios/Config.xcconfig
@@ -8,3 +8,4 @@
 // Configuration settings file format documentation can be found at:
 // https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project
 #include? "tmp.xcconfig"
+

--- a/Frontend/ios/Frontend/Info.plist
+++ b/Frontend/ios/Frontend/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -29,21 +34,9 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>디버깅을 위해 로컬 네트워크 접근이 필요합니다.</string>
-	<key>NSBonjourServices</key>
-	<array>
-	<string>_http._tcp</string>
-	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSAllowsArbitraryLoadsInWebContent</key>
-    	<true/>
-		<key>NSAllowsLocalNetworking</key>
-		<true/>
-	</dict>
+	
+	
+
 	<key>NSCameraUsageDescription</key>
 	<string>'다시 봄'이 카메라를 사용하여 사진을 촬영하기 위해 필요합니다.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/Frontend/ios/Frontend/Info.plist
+++ b/Frontend/ios/Frontend/Info.plist
@@ -38,7 +38,9 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<false/>
+		<true/>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+    	<true/>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>

--- a/Frontend/ios/Podfile.lock
+++ b/Frontend/ios/Podfile.lock
@@ -2080,11 +2080,6 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSound (0.11.2):
-    - React-Core
-    - RNSound/Core (= 0.11.2)
-  - RNSound/Core (0.11.2):
-    - React-Core
   - RNSVG (15.12.0):
     - React-Core
   - SocketRocket (0.7.1)
@@ -2216,7 +2211,6 @@ DEPENDENCIES:
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
-  - RNSound (from `../node_modules/react-native-sound`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - SplashView (from `../node_modules/react-native-splash-view`)
   - VisionCamera (from `../node_modules/react-native-vision-camera`)
@@ -2416,8 +2410,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
     :path: "../node_modules/react-native-screens"
-  RNSound:
-    :path: "../node_modules/react-native-sound"
   RNSVG:
     :path: "../node_modules/react-native-svg"
   SplashView:
@@ -2523,7 +2515,6 @@ SPEC CHECKSUMS:
   RNPermissions: 3d8a74b3822f9496795ed115a56dbfde13521021
   RNReanimated: d5e68954fe8409a6555f33551c9297ef1648543e
   RNScreens: 4561eef339c3ebe8176b27e01af7ac494780f678
-  RNSound: 6c156f925295bdc83e8e422e7d8b38d33bc71852
   RNSVG: 769d0a2e79162d08639e1fbb43031adac58ed24c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SplashView: 153fb6488ffbac3e54b3b54b778497be5b39c1d8

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/native-stack": "^7.3.10",
         "@react-navigation/stack": "^7.2.10",
+        "@reduxjs/toolkit": "^2.8.2",
         "@tanstack/react-query": "^5.74.4",
         "axios": "^1.9.0",
         "date-fns": "^4.1.0",
@@ -52,7 +53,8 @@
         "react-native-video-controls": "^2.8.1",
         "react-native-video-player": "^0.16.3",
         "react-native-vision-camera": "^4.6.4",
-        "react-native-webview": "^13.13.5"
+        "react-native-webview": "^13.13.5",
+        "react-redux": "^9.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -3852,6 +3854,38 @@
         "react-native-screens": ">= 4.0.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -3899,6 +3933,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -4468,6 +4514,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -8318,6 +8370,16 @@
       },
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -12900,6 +12962,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -12957,6 +13042,21 @@
       "peerDependencies": {
         "react": ">= 15.2.1",
         "react-native": ">= 0.30.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -22,6 +22,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/native-stack": "^7.3.10",
     "@react-navigation/stack": "^7.2.10",
+    "@reduxjs/toolkit": "^2.8.2",
     "@tanstack/react-query": "^5.74.4",
     "axios": "^1.9.0",
     "date-fns": "^4.1.0",
@@ -54,7 +55,8 @@
     "react-native-video-controls": "^2.8.1",
     "react-native-video-player": "^0.16.3",
     "react-native-vision-camera": "^4.6.4",
-    "react-native-webview": "^13.13.5"
+    "react-native-webview": "^13.13.5",
+    "react-redux": "^9.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/Frontend/src/api/auth.ts
+++ b/Frontend/src/api/auth.ts
@@ -1,4 +1,4 @@
-import axiosInstance from 'axios';
+import axiosInstance from '@/api/axios';
 import {getEncryptStorage} from '@/utils';
 import type {
   KakaoLoginResponse,
@@ -27,7 +27,6 @@ export const postSignup = async (
 export const getAccessToken = async (): Promise<TokenResponse> => {
   const refreshToken = await getEncryptStorage(storageKeys.REFRESH_TOKEN);
 
-  // ❶ 빈 바디를 두고 ❷ 헤더는 세 번째 인자로 전달
   const {data} = await axiosInstance.post(
     '/api/auth/reissue',
     {}, // 빈 바디
@@ -40,7 +39,6 @@ export const getAccessToken = async (): Promise<TokenResponse> => {
 
   // 만약 API가 { result: TokenResponse } 형태라면:
   // return data.result;
-
   // 아니라 data가 곧 TokenResponse라면:
   return data;
 };

--- a/Frontend/src/api/auth.ts
+++ b/Frontend/src/api/auth.ts
@@ -7,10 +7,11 @@ import type {
   SignupRequest,
   SignupResponse,
 } from '@/types/auth';
+import {storageKeys} from '@/constants';
 
 export const kakaoLogin = async (code: string): Promise<KakaoLoginResponse> => {
   const endpoint = `/api/auth/login?code=${encodeURIComponent(code)}`;
-  const {data} = await axiosInstance.post<KakaoLoginResponse>(endpoint, {});
+  const {data} = await axiosInstance.post<KakaoLoginResponse>(endpoint);
   return data;
 };
 
@@ -23,22 +24,30 @@ export const postSignup = async (
   );
   return data;
 };
-
 export const getAccessToken = async (): Promise<TokenResponse> => {
-  const refreshToken = await getEncryptStorage('refreshToken');
+  const refreshToken = await getEncryptStorage(storageKeys.REFRESH_TOKEN);
 
-  const {data} = await axiosInstance.get('/api/auth/reissue', {
-    headers: {
-      Authorization: `Bearer ${refreshToken}`,
+  // ❶ 빈 바디를 두고 ❷ 헤더는 세 번째 인자로 전달
+  const {data} = await axiosInstance.post(
+    '/api/auth/reissue',
+    {}, // 빈 바디
+    {
+      headers: {
+        Authorization: `Bearer ${refreshToken}`,
+      },
     },
-  });
+  );
 
+  // 만약 API가 { result: TokenResponse } 형태라면:
+  // return data.result;
+
+  // 아니라 data가 곧 TokenResponse라면:
   return data;
 };
 
-export const getProfile = async (authCode: string): Promise<UserInfo> => {
-  const {data} = await axiosInstance.post<UserInfo>('/api/auth/signup');
-  return data;
+export const getProfile = async (): Promise<UserInfo> => {
+  const {data} = await axiosInstance.post('/api/auth/profile');
+  return data.result;
 };
 
 export const logout = async (): Promise<void> => {

--- a/Frontend/src/api/auth.ts
+++ b/Frontend/src/api/auth.ts
@@ -18,29 +18,29 @@ export const kakaoLogin = async (code: string): Promise<KakaoLoginResponse> => {
 export const postSignup = async (
   payload: SignupRequest,
 ): Promise<SignupResponse> => {
+  console.log('▶️ [postSignup] payload:', payload);
+
   const {data} = await axiosInstance.post<SignupResponse>(
     '/api/auth/signup',
     payload,
   );
+  console.log('◀️ [postSignup] response data:', data);
   return data;
 };
+
 export const getAccessToken = async (): Promise<TokenResponse> => {
   const refreshToken = await getEncryptStorage(storageKeys.REFRESH_TOKEN);
 
   const {data} = await axiosInstance.post(
     '/api/auth/reissue',
-    {}, // 빈 바디
+    {},
     {
       headers: {
         Authorization: `Bearer ${refreshToken}`,
       },
     },
   );
-
-  // 만약 API가 { result: TokenResponse } 형태라면:
-  // return data.result;
-  // 아니라 data가 곧 TokenResponse라면:
-  return data;
+  return data.result;
 };
 
 export const getProfile = async (): Promise<UserInfo> => {

--- a/Frontend/src/api/axios.ts
+++ b/Frontend/src/api/axios.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const axiosInstance = axios.create({
   baseURL: 'http://43.201.159.48:8080/',
-  withCredentials: true,
+  // withCredentials: true,
 });
 
 export default axiosInstance;

--- a/Frontend/src/hooks/queries/useAuth.ts
+++ b/Frontend/src/hooks/queries/useAuth.ts
@@ -1,55 +1,66 @@
-import {useEffect} from 'react';
-import {useMutation, useQuery} from '@tanstack/react-query';
-
-import {
-  kakaoLogin,
-  postSignup,
-  getAccessToken,
-  getProfile,
-  logout,
-  signout,
-} from '@/api/auth';
+import {useEffect, useState} from 'react';
+import {useMutation} from '@tanstack/react-query';
+import {kakaoLogin, postSignup} from '@/api/auth';
 import type {
   KakaoLoginResponse,
-  TokenResponse,
-  UserInfo,
   SignupRequest,
   SignupResponse,
+  UserInfo,
 } from '@/types/auth';
 import {
   setHeader,
-  removeHeader,
   setEncryptStorage,
+  removeHeader,
   removeEncryptStorage,
 } from '@/utils';
 import queryClient from '@/api/queryClient';
-import {numbers, queryKeys, storageKeys} from '@/constants';
-import type {
-  ResponseError,
-  UseMutationCustomOptions,
-  UseQueryCustomOptions,
-} from '@/types/common';
+import {queryKeys, storageKeys} from '@/constants';
+import {
+  useGetRefreshToken,
+  useGetProfile,
+  useLogout,
+  useDeleteAccount,
+} from '@/hooks/queries/useAuthHelpers';
 
-export function useSignup(mutationOptions?: UseMutationCustomOptions) {
-  return useMutation({
+function useAuth() {
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
+  const [profileComplete, setProfileComplete] = useState(false);
+
+  // 1) 회원가입: 성공 시 profileComplete = true
+  const signupMutation = useMutation<SignupResponse, Error, SignupRequest>({
     mutationFn: postSignup,
-    ...mutationOptions,
+    onSuccess: () => {
+      setProfileComplete(true);
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.AUTH, queryKeys.GET_PROFILE],
+      });
+    },
   });
-}
-export function useKakaoLogin(
-  mutationOptions?: UseMutationCustomOptions<KakaoLoginResponse>,
-) {
-  return useMutation({
+
+  // 2) 카카오 로그인: firstLogin 기반으로 profileComplete 세팅
+  const kakaoLoginMutation = useMutation<KakaoLoginResponse, any, string>({
     mutationFn: kakaoLogin,
     onSuccess: res => {
       const {firstLogin, tokenResponse, userInfo} = res.result;
+
+      if (tokenResponse) {
+        setHeader('Authorization', `Bearer ${tokenResponse.accessToken}`);
+        setEncryptStorage(
+          storageKeys.REFRESH_TOKEN,
+          tokenResponse.refreshToken,
+        );
+      }
+
+      // 첫 로그인(false) 이 아닌 경우 existing user → profileComplete true
+      setProfileComplete(!firstLogin);
+
+      // 첫 로그인 시, 닉네임·이미지 미리 세팅
       if (firstLogin && userInfo) {
-        queryClient.setQueryData(
+        queryClient.setQueryData<UserInfo>(
           [queryKeys.AUTH, queryKeys.GET_PROFILE],
           userInfo,
         );
       }
-      // …
     },
     onSettled: () => {
       queryClient.refetchQueries({
@@ -59,134 +70,28 @@ export function useKakaoLogin(
         queryKey: [queryKeys.AUTH, queryKeys.GET_PROFILE],
       });
     },
-    ...mutationOptions,
-  });
-}
-
-export function useGetRefreshToken() {
-  const {data, error, isSuccess, isError, isPending} = useQuery({
-    queryKey: [queryKeys.AUTH, queryKeys.GET_ACCESS_TOKEN],
-    queryFn: getAccessToken,
-    staleTime: numbers.ACCESS_TOKEN_REFRESH_TIME,
-    refetchInterval: numbers.ACCESS_TOKEN_REFRESH_TIME,
-    refetchOnReconnect: true,
-    refetchIntervalInBackground: true,
   });
 
-  useEffect(() => {
-    if (isSuccess) {
-      setHeader('Authorization', `Bearer ${data.accessToken}`);
-      setEncryptStorage(storageKeys.REFRESH_TOKEN, data.refreshToken);
-    }
-  }, [isSuccess]);
-
-  useEffect(() => {
-    if (isError) {
-      removeHeader('Authorization');
-      removeEncryptStorage(storageKeys.REFRESH_TOKEN);
-    }
-  }, [isError]);
-
-  return {isSuccess, isError, isPending};
-}
-// export function useGetProfile(options?: UseQueryCustomOptions<UserInfo>) {
-//   return useQuery<UserInfo, ResponseError>({
-//     queryKey: [queryKeys.AUTH, queryKeys.GET_PROFILE],
-
-//     queryFn: () => {
-//       const cached = queryClient.getQueryData<UserInfo>([
-//         queryKeys.AUTH,
-//         queryKeys.GET_PROFILE,
-//       ]);
-//       if (!cached) {
-//         throw new Error('로그인 후 프로필 정보가 없습니다');
-//       }
-//       return cached;
-//     },
-
-//     enabled: false,
-//     initialData: () =>
-//       queryClient.getQueryData<UserInfo>([
-//         queryKeys.AUTH,
-//         queryKeys.GET_PROFILE,
-//       ])!,
-
-//     ...options,
-//   });
-// }
-
-export function useGetProfile(options?: any) {
-  return useQuery<UserInfo>({
-    queryKey: [queryKeys.AUTH, queryKeys.GET_PROFILE],
-    queryFn: getProfile,
-    enabled: true, // *항상* 서버에서 프로필을 가져오도록
-    ...options,
-  });
-}
-
-export function useLogout(mutationOptions?: UseMutationCustomOptions) {
-  return useMutation({
-    mutationFn: logout,
-    onSuccess: () => {
-      removeHeader('Authorization');
-      removeEncryptStorage(storageKeys.REFRESH_TOKEN);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({queryKey: [queryKeys.AUTH]});
-    },
-    ...mutationOptions,
-  });
-}
-
-export function useDeleteAccount(mutationOptions?: UseMutationCustomOptions) {
-  return useMutation({
-    mutationFn: signout,
-    onSuccess: () => {
-      removeHeader('Authorization');
-      removeEncryptStorage(storageKeys.REFRESH_TOKEN);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({queryKey: [queryKeys.AUTH]});
-    },
-    ...mutationOptions,
-  });
-}
-
-function useAuth() {
-  const signupMutation = useMutation<SignupResponse, Error, SignupRequest>({
-    mutationFn: postSignup,
-    onSuccess: () => {
-      // 프로필을 다시 불러오면, 이제 userInfo 가 완전해집니다
-      queryClient.invalidateQueries({
-        queryKey: [queryKeys.AUTH, queryKeys.GET_PROFILE],
-      });
-    },
-  });
-  const kakaoLoginMutation = useMutation<KakaoLoginResponse, any, string>({
-    mutationFn: kakaoLogin,
-    onSuccess: res => {
-      if (res.result.tokenResponse) {
-        // 기존 로그인 유저: 토큰 세팅
-        setHeader(
-          'Authorization',
-          `Bearer ${res.result.tokenResponse.accessToken}`,
-        );
-        setEncryptStorage(
-          storageKeys.REFRESH_TOKEN,
-          res.result.tokenResponse.refreshToken,
-        );
-      }
-    },
-  });
   const refreshQuery = useGetRefreshToken();
-  const profileQuery = useGetProfile();
+  const profileQuery = useGetProfile(); // UI용 프로필 조회
   const logoutMutation = useLogout();
   const deleteAccountMutation = useDeleteAccount();
 
-  // 1) “로그인(토큰갱신) 성공” 여부
-  const isAuthenticated = refreshQuery.isSuccess;
-  // 2) “프로필 조회” 성공 여부 → 첫 로그인 유저는 postSignup 전까지 false
-  const isProfileComplete = profileQuery.isSuccess;
+  // 로그아웃·탈퇴 시 profileComplete 리셋
+  useEffect(() => {
+    if (logoutMutation.isSuccess || deleteAccountMutation.isSuccess) {
+      setProfileComplete(false);
+      removeHeader('Authorization');
+      removeEncryptStorage(storageKeys.REFRESH_TOKEN);
+    }
+  }, [logoutMutation.isSuccess, deleteAccountMutation.isSuccess]);
+
+  // 토큰확인 로딩 끝나면 초기 로딩 false
+  useEffect(() => {
+    if (!refreshQuery.isLoading) {
+      setIsInitialLoading(false);
+    }
+  }, [refreshQuery.isLoading]);
 
   return {
     signupMutation,
@@ -195,12 +100,9 @@ function useAuth() {
     profileQuery,
     logoutMutation,
     deleteAccountMutation,
-    // 로그인 상태
-    isAuthenticated,
-    // 회원가입(프로필 완성) 상태
-    isProfileComplete,
-    // 전체 로딩 플래그
-    isLoading: refreshQuery.isPending,
+    isAuthenticated: refreshQuery.isSuccess,
+    isProfileComplete: profileComplete,
+    isLoading: isInitialLoading,
   };
 }
 

--- a/Frontend/src/hooks/queries/useAuthHelpers.ts
+++ b/Frontend/src/hooks/queries/useAuthHelpers.ts
@@ -1,0 +1,88 @@
+import {useEffect} from 'react';
+import {useMutation, useQuery} from '@tanstack/react-query';
+import {getAccessToken, getProfile, logout, signout} from '@/api/auth';
+import type {UserInfo} from '@/types/auth';
+import {
+  setHeader,
+  removeHeader,
+  setEncryptStorage,
+  removeEncryptStorage,
+} from '@/utils';
+import queryClient from '@/api/queryClient';
+import {numbers, queryKeys, storageKeys} from '@/constants';
+import type {UseMutationCustomOptions} from '@/types/common';
+
+/**
+ * AccessToken 갱신
+ */
+export function useGetRefreshToken() {
+  const {data, isSuccess, isError, isLoading} = useQuery({
+    queryKey: [queryKeys.AUTH, queryKeys.GET_ACCESS_TOKEN],
+    queryFn: getAccessToken,
+    staleTime: numbers.ACCESS_TOKEN_REFRESH_TIME,
+    refetchInterval: numbers.ACCESS_TOKEN_REFRESH_TIME,
+    refetchOnReconnect: true,
+    refetchIntervalInBackground: true,
+  });
+
+  useEffect(() => {
+    if (isSuccess) {
+      setHeader('Authorization', `Bearer ${data.accessToken}`);
+      setEncryptStorage(storageKeys.REFRESH_TOKEN, data.refreshToken);
+    }
+  }, [isSuccess]);
+
+  useEffect(() => {
+    if (isError) {
+      removeHeader('Authorization');
+      removeEncryptStorage(storageKeys.REFRESH_TOKEN);
+    }
+  }, [isError]);
+
+  return {isSuccess, isError, isLoading};
+}
+
+/**
+ *  프로필 조회
+ */
+export function useGetProfile() {
+  return useQuery<UserInfo>({
+    queryKey: [queryKeys.AUTH, queryKeys.GET_PROFILE],
+    queryFn: getProfile, // UI에서 프로필 조회 용
+    enabled: true,
+  });
+}
+
+/**
+ * 로그아웃
+ */
+export function useLogout(mutationOptions?: UseMutationCustomOptions) {
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      removeHeader('Authorization');
+      removeEncryptStorage(storageKeys.REFRESH_TOKEN);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({queryKey: [queryKeys.AUTH]});
+    },
+    ...mutationOptions,
+  });
+}
+
+/**
+ * 회원 탈퇴
+ */
+export function useDeleteAccount(mutationOptions?: UseMutationCustomOptions) {
+  return useMutation({
+    mutationFn: signout,
+    onSuccess: () => {
+      removeHeader('Authorization');
+      removeEncryptStorage(storageKeys.REFRESH_TOKEN);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({queryKey: [queryKeys.AUTH]});
+    },
+    ...mutationOptions,
+  });
+}

--- a/Frontend/src/hooks/useForm.ts
+++ b/Frontend/src/hooks/useForm.ts
@@ -5,7 +5,7 @@ interface UseFormProps<T> {
   validate: (values: T) => Record<keyof T, string>;
 }
 
-function useForm<T>({initialValue, validate}: UseFormProps<T>) {
+export default function useForm<T>({initialValue, validate}: UseFormProps<T>) {
   const [values, setValues] = useState(initialValue);
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -59,5 +59,3 @@ function useForm<T>({initialValue, validate}: UseFormProps<T>) {
     getFieldProps,
   };
 }
-
-export default useForm;

--- a/Frontend/src/navigations/root/RootNavigator.tsx
+++ b/Frontend/src/navigations/root/RootNavigator.tsx
@@ -1,5 +1,5 @@
 // src/navigations/root/RootNavigator.tsx
-import React from 'react';
+import React, {useEffect} from 'react';
 import {Text, View, ActivityIndicator} from 'react-native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import AuthStackNavigator from '../stack/AuthStackNavigator';
@@ -8,56 +8,66 @@ import TapNavigator from '../tab/TabNavigator';
 import useAuth from '@/hooks/queries/useAuth';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {authNavigations} from '@/constants';
+import {hideSplash, showSplash} from 'react-native-splash-view';
 
 // 연동 시, 아래 코드 주석 해제
-// export type AuthStackParamList = {
-//   [authNavigations.SIGNUP]: {authCode: string};
-// };
+export type AuthStackParamList = {
+  [authNavigations.SIGNUP]: {authCode: string};
+};
 
-// const Stack = createNativeStackNavigator<AuthStackParamList>();
+const Stack = createNativeStackNavigator<AuthStackParamList>();
 
-// export default function RootNavigator() {
-//   const {isAuthenticated, isProfileComplete, isLoading} = useAuth();
+export default function RootNavigator() {
+  const {isAuthenticated, isProfileComplete, isLoading} = useAuth();
 
-//   // 0) 아직 토큰 확인 중
-//   if (isLoading) {
-//     return (
-//       <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
-//         <ActivityIndicator size="large" />
-//       </View>
-//     );
-//   }
+  showSplash();
 
-//   // 1) 토큰이 없으면 → 로그인/카카오로그인/회원가입 스택
-//   if (!isAuthenticated) {
-//     return <AuthStackNavigator />;
-//   }
+  useEffect(() => {
+    setTimeout(() => {
+      hideSplash();
+    }, 300);
+  }, []);
 
-//   // 2) 토큰은 있는데, 프로필(추가정보) 없으면 → SignupScreen
-//   if (!isProfileComplete) {
-//     return (
-//     <Stack.Navigator screenOptions={{headerShown: false}}>
-//       <Stack.Screen
-//         name={authNavigations.SIGNUP}
-//         component={SignupScreen}
-//         options={{
-//           headerTitle: '회원가입',
-//         }}
-//       />
-//     </Stack.Navigator>;
-//   }
+  // 0) 아직 토큰 확인 중
+  if (isLoading) {
+    return (
+      <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
 
-//   // 3) 모두 완료된 회원 → 메인 탭 네비게이터
-//   return <TapNavigator />;
-// }
+  // 1) 토큰이 없으면 → 로그인/카카오로그인/회원가입 스택
+  if (!isAuthenticated) {
+    return <AuthStackNavigator />;
+  }
+
+  // 2) 토큰은 있는데, 프로필(추가정보) 없으면 → SignupScreen
+  if (!isProfileComplete) {
+    return (
+      <Stack.Navigator screenOptions={{headerShown: false}}>
+        <Stack.Screen
+          name={authNavigations.SIGNUP}
+          component={SignupScreen}
+          options={{
+            headerTitle: '회원가입',
+          }}
+        />
+      </Stack.Navigator>
+    );
+  }
+
+  // 3) 모두 완료된 회원 → 메인 탭 네비게이터
+  return <TapNavigator />;
+}
 
 // 아래 코드로 테스트
 
-export default RootNavigator;
-function RootNavigator() {
-  const isLogin = true;
-  if (isLogin === undefined) {
-    return <Text>로딩중…</Text>;
-  }
-  return isLogin ? <TapNavigator /> : <AuthStackNavigator />;
-}
+// export default RootNavigator;
+// function RootNavigator() {
+//   const isLogin = true;
+//   if (isLogin === undefined) {
+//     return <Text>로딩중…</Text>;
+//   }
+//   return isLogin ? <TapNavigator /> : <AuthStackNavigator />;
+// }

--- a/Frontend/src/navigations/root/RootNavigator.tsx
+++ b/Frontend/src/navigations/root/RootNavigator.tsx
@@ -1,5 +1,4 @@
-// src/navigations/root/RootNavigator.tsx
-import React, {useEffect} from 'react';
+import React, {useEffect, useRef} from 'react';
 import {Text, View, ActivityIndicator} from 'react-native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import AuthStackNavigator from '../stack/AuthStackNavigator';
@@ -10,7 +9,6 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {authNavigations} from '@/constants';
 import {hideSplash, showSplash} from 'react-native-splash-view';
 
-// 연동 시, 아래 코드 주석 해제
 export type AuthStackParamList = {
   [authNavigations.SIGNUP]: {authCode: string};
 };
@@ -19,16 +17,19 @@ const Stack = createNativeStackNavigator<AuthStackParamList>();
 
 export default function RootNavigator() {
   const {isAuthenticated, isProfileComplete, isLoading} = useAuth();
-
-  showSplash();
+  const didShowSplash = useRef(false);
 
   useEffect(() => {
-    setTimeout(() => {
-      hideSplash();
-    }, 300);
+    showSplash();
+    didShowSplash.current = true;
   }, []);
 
-  // 0) 아직 토큰 확인 중
+  useEffect(() => {
+    if (didShowSplash.current && !isLoading) {
+      hideSplash();
+    }
+  }, [isLoading]);
+
   if (isLoading) {
     return (
       <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
@@ -37,12 +38,10 @@ export default function RootNavigator() {
     );
   }
 
-  // 1) 토큰이 없으면 → 로그인/카카오로그인/회원가입 스택
   if (!isAuthenticated) {
     return <AuthStackNavigator />;
   }
 
-  // 2) 토큰은 있는데, 프로필(추가정보) 없으면 → SignupScreen
   if (!isProfileComplete) {
     return (
       <Stack.Navigator screenOptions={{headerShown: false}}>
@@ -57,7 +56,6 @@ export default function RootNavigator() {
     );
   }
 
-  // 3) 모두 완료된 회원 → 메인 탭 네비게이터
   return <TapNavigator />;
 }
 

--- a/Frontend/src/screens/auth/KakaoLoginScreen.tsx
+++ b/Frontend/src/screens/auth/KakaoLoginScreen.tsx
@@ -1,11 +1,11 @@
-import React, {useState} from 'react';
+import React, {useState, useRef} from 'react';
 import {ActivityIndicator, SafeAreaView, StyleSheet, View} from 'react-native';
-import {WebView} from 'react-native-webview';
-import Config from 'react-native-config';
-import useAuth from '@/hooks/queries/useAuth';
-import {authNavigations, colors, homeNavigations} from '@/constants';
+import {WebView, WebViewNavigation} from 'react-native-webview';
 import type {StackScreenProps} from '@react-navigation/stack';
-import type {AuthStackParamList} from '@/navigations/stack/AuthStackNavigator';
+import {AuthStackParamList} from '@/navigations/stack/AuthStackNavigator';
+import {authNavigations, colors} from '@/constants';
+import useAuth from '@/hooks/queries/useAuth';
+import Config from 'react-native-config';
 
 type Props = StackScreenProps<
   AuthStackParamList,
@@ -13,90 +13,62 @@ type Props = StackScreenProps<
 >;
 
 export default function KakaoLoginScreen({navigation}: Props) {
-  const CLIENT_ID = Config.KAKAO_CLIENT_ID!;
-  const REDIRECT_URI = Config.KAKAO_REDIRECT_URI!;
-
   const {kakaoLoginMutation} = useAuth();
   const [loading, setLoading] = useState(false);
-  const [handled, setHandled] = useState(false);
+  const handledRef = useRef(false);
 
-  // 콜백 URL 접두사
-  const callbackPrefix = `${REDIRECT_URI}?code=`;
+  const handleShouldStartLoad = (request: {url: string}) => {
+    const {url} = request;
+    console.log('⏳ shouldStartLoad:', url);
 
-  // URL이 콜백 패턴에 맞으면 한 번만 처리
-  const handleCode = (url: string) => {
-    if (handled || !url.startsWith(callbackPrefix)) return;
+    if (
+      !handledRef.current &&
+      url.startsWith(`${Config.KAKAO_REDIRECT_URI}?code=`)
+    ) {
+      handledRef.current = true;
+      const code = url.split('code=')[1]!;
+      console.log('✅ [WebView] intercept code:', code);
 
-    setHandled(true);
-    const code = url.substring(callbackPrefix.length).split('&')[0];
-    setLoading(true);
+      setLoading(true);
 
-    kakaoLoginMutation.mutate(code, {
-      onSuccess: res => {
-        if (res.result.firstLogin) {
-          navigation.replace(authNavigations.SIGNUP, {authCode: code});
-        } else {
-          navigation.getParent()?.reset({
-            index: 0,
-            routes: [{name: homeNavigations.MAIN_HOME}],
-          });
-        }
-      },
-      onSettled: () => setLoading(false),
-    });
+      console.log(
+        '➡️ [Mutate] calling kakaoLoginMutation.mutate with code:',
+        code,
+      );
+      kakaoLoginMutation.mutate(code, {
+        onSuccess: res => {
+          console.log('✅ [API] kakaoLogin SUCCESS, response:', res);
+          navigation.replace(authNavigations.SIGNUP, {authCode: code} as any);
+        },
+        onError: err => {
+          console.error('❌ [API] kakaoLogin ERROR:', err);
+          setLoading(false);
+          handledRef.current = false;
+        },
+      });
+
+      return false;
+    }
+
+    return true; // 그 외의 URL은 정상 로드
   };
 
-  // 1) 로그인 처리 중
-  if (loading) {
-    return (
-      <View style={styles.loader}>
-        <ActivityIndicator size="large" color={colors.MAINBLUE} />
-      </View>
-    );
-  }
-
-  // 2) 콜백 처리 후에는 WebView 언마운트
-  if (handled) {
-    return null;
-  }
-
-  // 3) 카카오 인증 WebView
   return (
     <SafeAreaView style={styles.container}>
+      {loading && (
+        <View style={styles.loader}>
+          <ActivityIndicator size="large" color={colors.BLACK} />
+        </View>
+      )}
+
       <WebView
+        style={styles.container}
         source={{
-          uri:
-            `https://kauth.kakao.com/oauth/authorize` +
-            `?response_type=code` +
-            `&client_id=${CLIENT_ID}` +
-            `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}`,
+          uri: `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${Config.KAKAO_CLIENT_ID}&redirect_uri=${Config.KAKAO_REDIRECT_URI}`,
         }}
-        // reCAPTCHA가 mixed content 로 로드될 경우
-        mixedContentMode="always"
-        userAgent="Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
+        onShouldStartLoadWithRequest={handleShouldStartLoad}
         javaScriptEnabled
         domStorageEnabled
-        sharedCookiesEnabled
-        originWhitelist={['*']}
-        onShouldStartLoadWithRequest={({url}) => {
-          handleCode(url);
-          // 콜백 처리 전까지만 로드 허용
-          return !handled;
-        }}
-        onNavigationStateChange={({url}) => {
-          handleCode(url);
-        }}
-        style={{flex: 1}}
-        onMessage={evt => {
-          // 사이트에서 postMessage 해 주는 reCAPTCHA 토큰 받기
-          console.log('reCAPTCHA token:', evt.nativeEvent.data);
-        }}
-        startInLoadingState
-        renderLoading={() => (
-          <View style={styles.loader}>
-            <ActivityIndicator size="large" color={colors.MAINBLUE} />
-          </View>
-        )}
       />
     </SafeAreaView>
   );
@@ -104,5 +76,10 @@ export default function KakaoLoginScreen({navigation}: Props) {
 
 const styles = StyleSheet.create({
   container: {flex: 1},
-  loader: {flex: 1, alignItems: 'center', justifyContent: 'center'},
+  loader: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.WHITE,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
 });

--- a/Frontend/src/screens/auth/KakaoLoginScreen.tsx
+++ b/Frontend/src/screens/auth/KakaoLoginScreen.tsx
@@ -1,50 +1,66 @@
 import React, {useState} from 'react';
-import {
-  ActivityIndicator,
-  SafeAreaView,
-  StyleSheet,
-  View,
-  Dimensions,
-} from 'react-native';
-import {WebView, WebViewNavigation} from 'react-native-webview';
+import {ActivityIndicator, SafeAreaView, StyleSheet, View} from 'react-native';
+import {WebView} from 'react-native-webview';
 import Config from 'react-native-config';
 import useAuth from '@/hooks/queries/useAuth';
-import {authNavigations, colors} from '@/constants';
-import {AuthStackParamList} from '@/navigations/stack/AuthStackNavigator';
-import {StackScreenProps} from '@react-navigation/stack';
+import {authNavigations, colors, homeNavigations} from '@/constants';
+import type {StackScreenProps} from '@react-navigation/stack';
+import type {AuthStackParamList} from '@/navigations/stack/AuthStackNavigator';
 
-const CLIENT_ID = Config.KAKAO_CLIENT_ID as string;
-const REDIRECT_URI = Config.KAKAO_REDIRECT_URI as string;
-type KakaoLoginScreenProps = StackScreenProps<
+type Props = StackScreenProps<
   AuthStackParamList,
   typeof authNavigations.KAKAO_LOGIN
 >;
-function KakaoLoginScreen({navigation}: KakaoLoginScreenProps) {
+
+export default function KakaoLoginScreen({navigation}: Props) {
+  const CLIENT_ID = Config.KAKAO_CLIENT_ID!;
+  const REDIRECT_URI = Config.KAKAO_REDIRECT_URI!;
+
   const {kakaoLoginMutation} = useAuth();
   const [loading, setLoading] = useState(false);
+  const [handled, setHandled] = useState(false);
 
-  const handleNavChange = (event: WebViewNavigation) => {
-    const {url, loading: navLoading} = event;
-    // console.log('URLsfdfsfs:', event.url);
+  // 콜백 URL 접두사
+  const callbackPrefix = `${REDIRECT_URI}?code=`;
 
-    if (!navLoading && url.startsWith(`${REDIRECT_URI}?code=`)) {
-      const code = url.split('?code=')[1];
-      setLoading(true);
+  // URL이 콜백 패턴에 맞으면 한 번만 처리
+  const handleCode = (url: string) => {
+    if (handled || !url.startsWith(callbackPrefix)) return;
 
-      kakaoLoginMutation.mutate(code, {
-        onSettled: () => setLoading(false),
-      });
-    }
+    setHandled(true);
+    const code = url.substring(callbackPrefix.length).split('&')[0];
+    setLoading(true);
+
+    kakaoLoginMutation.mutate(code, {
+      onSuccess: res => {
+        if (res.result.firstLogin) {
+          navigation.replace(authNavigations.SIGNUP, {authCode: code});
+        } else {
+          navigation.getParent()?.reset({
+            index: 0,
+            routes: [{name: homeNavigations.MAIN_HOME}],
+          });
+        }
+      },
+      onSettled: () => setLoading(false),
+    });
   };
 
+  // 1) 로그인 처리 중
   if (loading) {
     return (
       <View style={styles.loader}>
-        <ActivityIndicator size="large" color={colors.BLACK} />
+        <ActivityIndicator size="large" color={colors.MAINBLUE} />
       </View>
     );
   }
 
+  // 2) 콜백 처리 후에는 WebView 언마운트
+  if (handled) {
+    return null;
+  }
+
+  // 3) 카카오 인증 WebView
   return (
     <SafeAreaView style={styles.container}>
       <WebView
@@ -55,10 +71,32 @@ function KakaoLoginScreen({navigation}: KakaoLoginScreenProps) {
             `&client_id=${CLIENT_ID}` +
             `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}`,
         }}
-        // recaptcha 안뜨게 하는 코드
-        userAgent="Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"
-        onNavigationStateChange={handleNavChange}
+        // reCAPTCHA가 mixed content 로 로드될 경우
+        mixedContentMode="always"
+        userAgent="Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
+        javaScriptEnabled
+        domStorageEnabled
+        sharedCookiesEnabled
+        originWhitelist={['*']}
+        onShouldStartLoadWithRequest={({url}) => {
+          handleCode(url);
+          // 콜백 처리 전까지만 로드 허용
+          return !handled;
+        }}
+        onNavigationStateChange={({url}) => {
+          handleCode(url);
+        }}
+        style={{flex: 1}}
+        onMessage={evt => {
+          // 사이트에서 postMessage 해 주는 reCAPTCHA 토큰 받기
+          console.log('reCAPTCHA token:', evt.nativeEvent.data);
+        }}
         startInLoadingState
+        renderLoading={() => (
+          <View style={styles.loader}>
+            <ActivityIndicator size="large" color={colors.MAINBLUE} />
+          </View>
+        )}
       />
     </SafeAreaView>
   );
@@ -66,13 +104,5 @@ function KakaoLoginScreen({navigation}: KakaoLoginScreenProps) {
 
 const styles = StyleSheet.create({
   container: {flex: 1},
-  loader: {
-    flex: 1,
-    backgroundColor: colors.WHITE,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
+  loader: {flex: 1, alignItems: 'center', justifyContent: 'center'},
 });
-// KakaoLoginScreen;
-
-export default KakaoLoginScreen;

--- a/Frontend/src/screens/auth/LoginScreen.tsx
+++ b/Frontend/src/screens/auth/LoginScreen.tsx
@@ -8,7 +8,6 @@ import {authNavigations, colors} from '@/constants';
 import MainIconBlue from '@/assets/icons/MainIconBlue.svg';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import Config from 'react-native-config';
-const TEST_CODE = Config.KAKAO_TEST_CODE;
 
 type LoginScreenProps = StackScreenProps<
   AuthStackParamList,
@@ -40,13 +39,7 @@ function LoginScreen({navigation}: LoginScreenProps) {
           variant="filled"
           size="large"
           onPress={() => {
-            if (__DEV__ && TEST_CODE) {
-              navigation.replace(authNavigations.SIGNUP, {
-                authCode: TEST_CODE,
-              });
-            } else {
-              navigation.navigate(authNavigations.KAKAO_LOGIN);
-            }
+            navigation.navigate(authNavigations.KAKAO_LOGIN);
           }}
           style={styles.kakaoButtonContainer}
           textStyle={styles.kakaoButtonText}

--- a/Frontend/src/screens/auth/LoginScreen.tsx
+++ b/Frontend/src/screens/auth/LoginScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Button, Dimensions, StyleSheet, Text, View} from 'react-native';
+import {Dimensions, StyleSheet, Text, View} from 'react-native';
 import {StackScreenProps} from '@react-navigation/stack';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {AuthStackParamList} from '@/navigations/stack/AuthStackNavigator';
@@ -7,7 +7,6 @@ import CustomButton from '@/components/commons/CustomButton';
 import {authNavigations, colors} from '@/constants';
 import MainIconBlue from '@/assets/icons/MainIconBlue.svg';
 import Ionicons from 'react-native-vector-icons/Ionicons';
-import Config from 'react-native-config';
 
 type LoginScreenProps = StackScreenProps<
   AuthStackParamList,

--- a/Frontend/src/screens/auth/SignupScreen.tsx
+++ b/Frontend/src/screens/auth/SignupScreen.tsx
@@ -14,12 +14,13 @@ import DateTimePickerModal from 'react-native-modal-datetime-picker';
 import {StackScreenProps} from '@react-navigation/stack';
 import useForm from '@/hooks/useForm';
 import useAuth from '@/hooks/queries/useAuth';
-import {useGetProfile} from '@/hooks/queries/useAuthHelpers';
 import {validateSignup} from '@/utils/validate';
 import {authNavigations, colors, homeNavigations} from '@/constants';
 import {AuthStackParamList} from '@/navigations/stack/AuthStackNavigator';
 import GenderToggle from '@/components/GenderToggle';
 import CustomButton from '@/components/commons/CustomButton';
+import type {SignupRequest} from '@/types/auth';
+import {Profile} from '@/types/profile';
 
 type SignupProps = StackScreenProps<
   AuthStackParamList,
@@ -27,12 +28,23 @@ type SignupProps = StackScreenProps<
 >;
 
 export default function SignupScreen({navigation}: SignupProps) {
-  const {data: profile, isLoading, isError} = useGetProfile();
-  const {signupMutation} = useAuth();
+  const {preSignupUserInfo, signupMutation} = useAuth();
   const [isDatePickerVisible, setDatePickerVisibility] = useState(false);
 
-  const form = useForm({
+  console.log('🟡 SignupScreen preSignupUserInfo:', preSignupUserInfo);
+  // 카카오 로그인 직후 userInfo 가 로드될 때까지 로딩 상태
+  if (!preSignupUserInfo) {
+    return (
+      <SafeAreaView style={styles.center}>
+        <ActivityIndicator size="large" color={colors.MAINBLUE} />
+      </SafeAreaView>
+    );
+  }
+  const form = useForm<Profile>({
     initialValue: {
+      kakaoId: preSignupUserInfo.kakaoId,
+      nickname: preSignupUserInfo.nickname,
+      profileImageUrl: preSignupUserInfo.profileImageUrl,
       gender: 'MALE',
       birth: '',
       isFaceRecognitionAgreed: false,
@@ -48,17 +60,17 @@ export default function SignupScreen({navigation}: SignupProps) {
   };
 
   const handleSignup = () => {
-    if (!profile) return;
     signupMutation.mutate(
       {
-        kakaoId: profile.kakaoId,
-        nickname: profile.nickname,
-        profileImageUrl: profile.profileImageUrl,
-        ...form.values,
+        kakaoId: preSignupUserInfo.kakaoId,
+        nickname: preSignupUserInfo.nickname,
+        profileImageUrl: preSignupUserInfo.profileImageUrl,
+        gender: form.values.gender,
+        birth: form.values.birth,
+        isFaceRecognitionAgreed: form.values.isFaceRecognitionAgreed,
       },
       {
         onSuccess: () => {
-          // 가입 성공 시 Main 탭으로 이동
           navigation.getParent()?.reset({
             index: 0,
             routes: [{name: homeNavigations.MAIN_HOME}],
@@ -68,43 +80,22 @@ export default function SignupScreen({navigation}: SignupProps) {
     );
   };
 
-  if (isLoading) {
-    return (
-      <SafeAreaView style={styles.container}>
-        <ActivityIndicator size="large" color={colors.MAINBLUE} />
-      </SafeAreaView>
-    );
-  }
-
-  if (isError || !profile) {
-    return (
-      <SafeAreaView style={styles.container}>
-        <Text style={{color: colors.RED, textAlign: 'center'}}>
-          프로필 정보를 불러오는 데 실패했습니다.
-        </Text>
-      </SafeAreaView>
-    );
-  }
-
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.form}>
-        {/* 아바타·닉네임 */}
         <View style={styles.inputContainer}>
           <Image
-            source={{uri: profile.profileImageUrl}}
+            source={{uri: preSignupUserInfo.profileImageUrl}}
             style={styles.avatar}
           />
-          <Text style={styles.nicknameText}>{profile.nickname}</Text>
+          <Text style={styles.nicknameText}>{preSignupUserInfo.nickname}</Text>
 
-          {/* 성별 */}
           <Text style={styles.label}>성별</Text>
           <GenderToggle
             value={form.values.gender}
             onChange={g => form.getFieldProps('gender').onChange(g)}
           />
 
-          {/* 생년월일 */}
           <Text style={styles.label}>생년월일</Text>
           <TouchableOpacity onPress={showDatePicker} activeOpacity={0.8}>
             <View style={[styles.dateInputContainer, styles.dateinput]}>
@@ -123,7 +114,6 @@ export default function SignupScreen({navigation}: SignupProps) {
             locale="ko"
           />
 
-          {/* 동의 토글 */}
           <View style={styles.consentContainer}>
             <Text style={styles.consentTitle}>안면 인식 이용 동의 (필수)</Text>
             <View style={styles.consentDescriptionWrapper}>
@@ -145,22 +135,45 @@ export default function SignupScreen({navigation}: SignupProps) {
             </View>
           </View>
         </View>
-
         <CustomButton
           label="완료"
           variant="filled"
           size="large"
           onPress={handleSignup}
+          disabled={signupMutation.status === 'pending'}
         />
+        {signupMutation.status === 'pending' && (
+          <ActivityIndicator
+            style={styles.loadingIndicator}
+            size="small"
+            color={colors.MAINBLUE}
+          />
+        )}
       </View>
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {flex: 1, padding: 20, justifyContent: 'center'},
-  form: {flex: 1, margin: 20, justifyContent: 'center'},
-  inputContainer: {flex: 1, marginVertical: 40},
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  form: {
+    flex: 1,
+    margin: 20,
+    justifyContent: 'center',
+  },
+  inputContainer: {
+    flex: 1,
+    marginVertical: 40,
+  },
   avatar: {
     width: 100,
     height: 100,
@@ -174,7 +187,10 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: 50,
   },
-  label: {fontSize: 15, marginBottom: 10},
+  label: {
+    fontSize: 15,
+    marginBottom: 10,
+  },
   dateinput: {
     borderBottomWidth: 1,
     borderColor: colors.LIGHTGRAY,
@@ -187,20 +203,38 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 24,
   },
-  dateText: {fontSize: 16},
-  consentContainer: {marginBottom: 32},
-  consentTitle: {fontSize: 16, fontWeight: '600', marginBottom: 8},
+  dateText: {
+    fontSize: 16,
+  },
+  consentContainer: {
+    marginBottom: 32,
+  },
+  consentTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
   consentDescriptionWrapper: {
     backgroundColor: colors.ALERTBACK,
     borderRadius: 10,
     padding: 5,
     marginBottom: 12,
   },
-  consentDescription: {fontSize: 14, color: colors.GRAY, lineHeight: 22},
+  consentDescription: {
+    fontSize: 14,
+    color: colors.GRAY,
+    lineHeight: 22,
+  },
   switchRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
   },
-  switchLabel: {fontSize: 15},
+  switchLabel: {
+    fontSize: 15,
+  },
+  loadingIndicator: {
+    marginTop: 10,
+    alignSelf: 'center',
+  },
 });

--- a/Frontend/src/store/index.ts
+++ b/Frontend/src/store/index.ts
@@ -1,0 +1,12 @@
+import {configureStore} from '@reduxjs/toolkit';
+import authReducer from '@/store/slices/authSlice';
+
+export const store = configureStore({
+  reducer: {
+    auth: authReducer,
+  },
+});
+
+// 루트 상태 타입 및 디스패치 타입
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/Frontend/src/store/slices/authSlice.ts
+++ b/Frontend/src/store/slices/authSlice.ts
@@ -1,0 +1,26 @@
+import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+import type {UserInfo} from '@/types/auth';
+
+interface AuthState {
+  preSignupUserInfo: UserInfo | null;
+}
+
+const initialState: AuthState = {
+  preSignupUserInfo: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setPreSignupUserInfo(state, action: PayloadAction<UserInfo>) {
+      state.preSignupUserInfo = action.payload;
+    },
+    clearPreSignupUserInfo(state) {
+      state.preSignupUserInfo = null;
+    },
+  },
+});
+
+export const {setPreSignupUserInfo, clearPreSignupUserInfo} = authSlice.actions;
+export default authSlice.reducer;

--- a/Frontend/src/types/auth.ts
+++ b/Frontend/src/types/auth.ts
@@ -15,6 +15,7 @@ export interface LoginResult {
   userInfo: UserInfo | null;
   firstLogin: boolean;
 }
+
 /** 공통 응답 래퍼 */
 export interface ApiResponse<T> {
   isSuccess: boolean;

--- a/Frontend/src/types/auth.ts
+++ b/Frontend/src/types/auth.ts
@@ -15,7 +15,6 @@ export interface LoginResult {
   userInfo: UserInfo | null;
   firstLogin: boolean;
 }
-
 /** 공통 응답 래퍼 */
 export interface ApiResponse<T> {
   isSuccess: boolean;
@@ -28,10 +27,7 @@ export interface ApiResponse<T> {
 export type KakaoLoginResponse = ApiResponse<LoginResult>;
 
 /** 회원가입 요청 페이로드 */
-export type SignupRequest = Pick<
-  Profile,
-  'gender' | 'birth' | 'isFaceRecognitionAgreed'
->;
+export type SignupRequest = Profile;
 
 /** 회원가입 응답 타입 */
 export interface SignupResponse {

--- a/Frontend/src/types/profile.ts
+++ b/Frontend/src/types/profile.ts
@@ -1,14 +1,15 @@
 // 카카오 로그인 직후, 회원가입 페이지에 보일 타입
 interface KakaoProfile {
+  kakaoId: number;
   nickname: string;
   profileImageUrl: string;
 }
 
 // 회원가입 시 서버에 보낼 전체 타입
 interface Profile {
-  kakaoId?: number;
+  kakaoId: number;
   nickname: string;
-  gender: 'MALE' | 'FEMALE' | 'OTHER';
+  gender: 'MALE' | 'FEMALE';
   birth: string;
   isFaceRecognitionAgreed: boolean;
   profileImageUrl: string;

--- a/Frontend/src/types/profile.ts
+++ b/Frontend/src/types/profile.ts
@@ -11,7 +11,7 @@ interface Profile {
   nickname: string;
   gender: 'MALE' | 'FEMALE';
   birth: string;
-  isFaceRecognitionAgreed: boolean;
+  faceRecognitionAgreed: boolean;
   profileImageUrl: string;
 }
 

--- a/Frontend/src/utils/validate.ts
+++ b/Frontend/src/utils/validate.ts
@@ -13,7 +13,7 @@ export function validateSignup(values: Profile): Record<keyof Profile, string> {
     profileImageUrl: '',
     gender: '',
     birth: '',
-    isFaceRecognitionAgreed: '',
+    faceRecognitionAgreed: '',
   };
 
   // 성별
@@ -27,8 +27,8 @@ export function validateSignup(values: Profile): Record<keyof Profile, string> {
   }
 
   // 안면 인식 동의
-  if (!values.isFaceRecognitionAgreed) {
-    errors.isFaceRecognitionAgreed = '안면인식 동의가 필요합니다.';
+  if (!values.faceRecognitionAgreed) {
+    errors.faceRecognitionAgreed = '안면인식 동의가 필요합니다.';
   }
 
   // nickname/profileImageUrl/kakaoId는 수정 불필요하니 빈 문자열 유지

--- a/Frontend/src/utils/validate.ts
+++ b/Frontend/src/utils/validate.ts
@@ -1,17 +1,16 @@
+// src/utils/validate.ts
+import type {Profile} from '@/types/profile';
+
 export function isBlank(value: string) {
   return value.trim() === '';
 }
 
-export interface SignupValues {
-  gender: 'MALE' | 'FEMALE';
-  birth: string;
-  isFaceRecognitionAgreed: boolean;
-}
-
-export function validateSignup(
-  values: SignupValues,
-): Record<keyof SignupValues, string> {
-  const errors: Record<keyof SignupValues, string> = {
+export function validateSignup(values: Profile): Record<keyof Profile, string> {
+  // 프로필 전체 키에 대해 빈 문자열로 초기화
+  const errors: Record<keyof Profile, string> = {
+    kakaoId: '',
+    nickname: '',
+    profileImageUrl: '',
     gender: '',
     birth: '',
     isFaceRecognitionAgreed: '',
@@ -22,15 +21,16 @@ export function validateSignup(
     errors.gender = '성별을 선택해주세요.';
   }
 
-  // 생년월일 검증: YYYY-MM-DD 형식
+  // 생년월일 YYYY-MM-DD 형식
   if (!/^\d{4}-\d{2}-\d{2}$/.test(values.birth)) {
     errors.birth = 'YYYY-MM-DD 형식으로 입력해주세요.';
   }
 
-  // 동의 여부 검증
+  // 안면 인식 동의
   if (!values.isFaceRecognitionAgreed) {
     errors.isFaceRecognitionAgreed = '안면인식 동의가 필요합니다.';
   }
 
+  // nickname/profileImageUrl/kakaoId는 수정 불필요하니 빈 문자열 유지
   return errors;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #54 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->

- 카카오로그인
- 회원가입
- 개인정보 

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->
![Simulator Screenshot - iPhone 16 Pro - 2025-05-31 at 13 21 28](https://github.com/user-attachments/assets/94daa59c-b76e-4635-bf4a-71c9b3bd6a90)
![Simulator Screenshot - iPhone 16 Pro - 2025-05-31 at 13 21 46](https://github.com/user-attachments/assets/b726a7b5-52ea-4f56-966d-840b10582c32)
![Simulator Screenshot - iPhone 16 Pro - 2025-05-31 at 13 09 10](https://github.com/user-attachments/assets/0eae18ec-3ca8-4b13-8b36-abaaf5f9df66)

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
경고창 ok-> 확인으로 바꾸겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Redux를 통한 인증 상태 및 사전 회원가입 정보 관리 도입
  - 개인정보 수집 동의서 아코디언(접이식) UI 및 상세 정책 안내 추가

- **기능 개선**
  - 회원가입 시 입력값 검증 강화 및 동의 미체크 시 경고 추가
  - 카카오 로그인 플로우 개선 및 OAuth 리다이렉트 처리 안정화
  - Splash 화면 표시 및 숨김 로직 개선
  - 회원가입 폼이 Redux의 사전 회원가입 정보로 자동 채워짐
  - UI 스크롤 및 레이아웃 개선

- **버그 수정**
  - 프로필 및 성별, 동의 항목 등 필드명 및 타입 일관성 강화
  - Info.plist 네트워크 권한 설정 정리

- **문서화**
  - 패키지 의존성 및 타입 선언 업데이트

- **리팩터링**
  - 인증 관련 훅 통합 및 코드 구조 개선
  - Redux Store 및 Slice 구조 도입

- **스타일**
  - 회원가입 화면 및 동의서 UI 스타일 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->