### PR TITLE
BE: [feat] 자가 진단 최종 결과 구성 #70

### DIFF
--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/controller/FinalDiagnosisController.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/controller/FinalDiagnosisController.java
@@ -1,8 +1,8 @@
 package gradude.springVision.domain.diagnosis.controller;
 
 import gradude.springVision.domain.diagnosis.dto.request.FinalDiagnosisRequestDTO;
-import gradude.springVision.domain.diagnosis.dto.response.FinalDiagnosisResponseDTO;
-import gradude.springVision.domain.diagnosis.service.FinalDiagnosisService;
+import gradude.springVision.domain.diagnosis.dto.response.LlmDiagnosisResponseDTO;
+import gradude.springVision.domain.diagnosis.service.LlmDiagnosisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,10 +11,10 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class FinalDiagnosisController {
 
-    private final FinalDiagnosisService finalDiagnosisService;
+    private final LlmDiagnosisService llmDiagnosisService;
 
     @PostMapping("/final")
-    public FinalDiagnosisResponseDTO analyzeSymptoms(@RequestBody FinalDiagnosisRequestDTO request) {
-        return finalDiagnosisService.analyzeSymptoms(request.getSymptoms());
+    public LlmDiagnosisResponseDTO analyzeSymptoms(@RequestBody FinalDiagnosisRequestDTO request) {
+        return llmDiagnosisService.analyzeSymptoms(request.getSymptoms());
     }
 }

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/dto/response/DiagnosisResponseDTO.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/dto/response/DiagnosisResponseDTO.java
@@ -14,6 +14,7 @@ public class DiagnosisResponseDTO {
     private int gaze;
     private int arm;
     private int totalScore;
+    private int totalScorePercentage;
     private String llmResult;
 
     public static DiagnosisResponseDTO from(Diagnosis diagnosis, String llmResult) {
@@ -24,6 +25,7 @@ public class DiagnosisResponseDTO {
                 .gaze(diagnosis.getGaze())
                 .arm(diagnosis.getArm())
                 .totalScore(diagnosis.getTotalScore())
+                .totalScorePercentage(diagnosis.getTotalScore() * 20)
                 .llmResult(llmResult)
                 .build();
     }

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/dto/response/DiagnosisResponseDTO.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/dto/response/DiagnosisResponseDTO.java
@@ -14,8 +14,9 @@ public class DiagnosisResponseDTO {
     private int gaze;
     private int arm;
     private int totalScore;
+    private String llmResult;
 
-    public static DiagnosisResponseDTO from(Diagnosis diagnosis) {
+    public static DiagnosisResponseDTO from(Diagnosis diagnosis, String llmResult) {
         return DiagnosisResponseDTO.builder()
                 .face(diagnosis.isFace())
                 .speech(diagnosis.isSpeech())
@@ -23,6 +24,7 @@ public class DiagnosisResponseDTO {
                 .gaze(diagnosis.getGaze())
                 .arm(diagnosis.getArm())
                 .totalScore(diagnosis.getTotalScore())
+                .llmResult(llmResult)
                 .build();
     }
 }

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/dto/response/LlmDiagnosisResponseDTO.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/dto/response/LlmDiagnosisResponseDTO.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class FinalDiagnosisResponseDTO {
+public class LlmDiagnosisResponseDTO {
     private String result;
 }

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/entity/Diagnosis.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/entity/Diagnosis.java
@@ -46,14 +46,19 @@ public class Diagnosis extends BaseEntity {
     @Min(0) @Max(5)
     private int totalScore;
 
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String llmResult;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    public void updateDiagnosis(SelfDiagnosisRequestDTO dto, int orientation, int totalScore) {
+    public void updateDiagnosis(SelfDiagnosisRequestDTO dto, int orientation, int totalScore, String llmResult) {
         this.orientation = orientation;
         this.gaze = dto.getGaze();
         this.arm = dto.getArm();
         this.totalScore = totalScore;
+        this.llmResult = llmResult;
     }
 }

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/service/DiagnosisCommandService.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/service/DiagnosisCommandService.java
@@ -43,8 +43,8 @@ public class DiagnosisCommandService {
     private final S3Service s3Service;
     private final LlmDiagnosisService llmDiagnosisService;
 
-    private static final String[] ALLOWED_VIDEO_EXTENSIONS = {"mp4"};
-    private static final String[] ALLOWED_AUDIO_EXTENSIONS = {"wav", "pcm"};
+    private static final String[] ALLOWED_VIDEO_EXTENSIONS = {"mp4", "mov"};
+    private static final String[] ALLOWED_AUDIO_EXTENSIONS = {"wav", "pcm", "m4a"};
 
     /**
      * 안면+음성 자가 진단

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/service/DiagnosisCommandService.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/service/DiagnosisCommandService.java
@@ -162,8 +162,6 @@ public class DiagnosisCommandService {
         int totalScore = orientation + selfDiagnosisRequestDTO.getGaze() + selfDiagnosisRequestDTO.getArm()
                         + (diagnosis.isFace() ? 1 : 0) + (diagnosis.isSpeech() ? 1 : 0);
 
-        diagnosis.updateDiagnosis(selfDiagnosisRequestDTO, orientation, totalScore);
-
         // 증상 문장 생성
         String symptoms = String.format(
                 "환자는 시선 이상 %s, 팔 움직임 이상 %s, 안면 마비 %s, 구음 장애 %s, 시간 인지 이상 %s, 나이 인지 이상 %s",
@@ -177,6 +175,8 @@ public class DiagnosisCommandService {
 
         // LLM 진단 결과
         String llmResult = llmDiagnosisService.analyzeSymptoms(symptoms).getResult();
+
+        diagnosis.updateDiagnosis(selfDiagnosisRequestDTO, orientation, totalScore, llmResult);
 
         return DiagnosisResponseDTO.from(diagnosis, llmResult);
     }

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/service/DiagnosisCommandService.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/service/DiagnosisCommandService.java
@@ -41,6 +41,7 @@ public class DiagnosisCommandService {
     private final UserRepository userRepository;
     private final DiagnosisRepository diagnosisRepository;
     private final S3Service s3Service;
+    private final LlmDiagnosisService llmDiagnosisService;
 
     private static final String[] ALLOWED_VIDEO_EXTENSIONS = {"mp4"};
     private static final String[] ALLOWED_AUDIO_EXTENSIONS = {"wav", "pcm"};
@@ -96,7 +97,9 @@ public class DiagnosisCommandService {
         }
     }
 
-    // 자가진단 AI API 호출
+    /**
+     * 자가진단 AI API 호출
+     */
     private Map<String, Object> callAiApi(String apiUrl, MultipartFile file) {
         RestTemplate restTemplate = new RestTemplate();
 
@@ -150,18 +153,31 @@ public class DiagnosisCommandService {
         }
 
         // 입력한 월(입력값 == 오늘 월), 만 나이 확인
-        int orientation = 0;
-        if (selfDiagnosisRequestDTO.getOrientationMonth() != today.getMonthValue()) {
-            if (selfDiagnosisRequestDTO.getOrientationAge() != age) {
-                orientation = 1;
-            }
-        }
+        boolean isMonthCorrect = selfDiagnosisRequestDTO.getOrientationMonth() == today.getMonthValue();
+        boolean isAgeCorrect = selfDiagnosisRequestDTO.getOrientationAge() == age;
+
+        // 둘 다 틀렸을 경우만 orientation 이상
+        int orientation = (!isMonthCorrect && !isAgeCorrect) ? 1 : 0;
 
         int totalScore = orientation + selfDiagnosisRequestDTO.getGaze() + selfDiagnosisRequestDTO.getArm()
                         + (diagnosis.isFace() ? 1 : 0) + (diagnosis.isSpeech() ? 1 : 0);
 
         diagnosis.updateDiagnosis(selfDiagnosisRequestDTO, orientation, totalScore);
 
-        return DiagnosisResponseDTO.from(diagnosis);
+        // 증상 문장 생성
+        String symptoms = String.format(
+                "환자는 시선 이상 %s, 팔 움직임 이상 %s, 안면 마비 %s, 구음 장애 %s, 시간 인지 이상 %s, 나이 인지 이상 %s",
+                selfDiagnosisRequestDTO.getGaze() == 1 ? "있음" : "없음",
+                selfDiagnosisRequestDTO.getArm() == 1 ? "있음" : "없음",
+                diagnosis.isFace() ? "있음" : "없음",
+                diagnosis.isSpeech() ? "있음" : "없음",
+                isMonthCorrect ? "없음" : "있음",
+                isAgeCorrect ? "없음" : "있음"
+        );
+
+        // LLM 진단 결과
+        String llmResult = llmDiagnosisService.analyzeSymptoms(symptoms).getResult();
+
+        return DiagnosisResponseDTO.from(diagnosis, llmResult);
     }
 }

--- a/Backend/src/main/java/gradude/springVision/domain/diagnosis/service/LlmDiagnosisService.java
+++ b/Backend/src/main/java/gradude/springVision/domain/diagnosis/service/LlmDiagnosisService.java
@@ -4,7 +4,7 @@ import com.theokanning.openai.completion.chat.ChatCompletionChoice;
 import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.theokanning.openai.completion.chat.ChatMessage;
 import com.theokanning.openai.service.OpenAiService;
-import gradude.springVision.domain.diagnosis.dto.response.FinalDiagnosisResponseDTO;
+import gradude.springVision.domain.diagnosis.dto.response.LlmDiagnosisResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -13,14 +13,28 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class FinalDiagnosisService {
+public class LlmDiagnosisService {
 
     @Value("${openai.model}")
     private String model;
 
     private final OpenAiService openAiService;
 
-    public FinalDiagnosisResponseDTO analyzeSymptoms(String symptoms) {
+    /**
+     * TODO - 프롬프트 수정해야 함
+     * ## 중증뇌졸중분류척도 **CG-FAST** 를 기준으로 뇌졸중척도 진단
+     *
+     * ### CG-FAST 기준
+     *
+     * - 의식수준 질의(나이, 월) → 0 / 1(둘 다 비정상일 경우 )
+     * - 주시편위 → 0 / 1
+     * - 얼굴마비 → 0 / 1
+     * - 팔마비 → 0 / 1
+     * - 구음장애/언어장애 → 0 / 1
+     *
+     * → 3점 이상이면 양성
+     */
+    public LlmDiagnosisResponseDTO analyzeSymptoms(String symptoms) {
         String persona = "당신은 뇌졸중 임상 진단 및 치료 전문가입니다.\n" +
                 "환자가 자연어로 표현한 증상을 바탕으로, 현재 임상적으로 고려해야 할 진단 소견, 관련된 뇌졸중 척도(예: CPSS, LAPSS, FAST 등)의 의미,\n" +
                 "그리고 적절한 치료 권고와 추후 관리 방안을 전문적이면서도 이해하기 쉽게 한국어로 설명해 주세요.";
@@ -46,6 +60,6 @@ public class FinalDiagnosisService {
 
         List<ChatCompletionChoice> choices = openAiService.createChatCompletion(request).getChoices();
         String result = choices.isEmpty() ? "응답이 없습니다." : choices.get(0).getMessage().getContent();
-        return new FinalDiagnosisResponseDTO(result);
+        return new LlmDiagnosisResponseDTO(result);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #70 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 최종 진단 결과에 LLM 결과도 포함
- LLM 결과 DB에 저장
- 자가 진단 최종 점수 퍼센티지화
- AI 진단 시 허용 파일 확장자 추가

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
llm 돌아가는데 15초 정도 걸리는거 전달하기!
llm 결과에 \n 있는거 처리해야 한다고도 전하기!